### PR TITLE
RBT(fix): update size when removing final node; fixes #43

### DIFF
--- a/packages/red-black-tree/src/functions/remove.ts
+++ b/packages/red-black-tree/src/functions/remove.ts
@@ -61,6 +61,7 @@ export function remove<K, V>(key: K, tree: RedBlackTreeImpl<K, V>): RedBlackTree
       return createTree<K, V>(false, tree._compare);
     }
     tree._root = NONE;
+    tree._size = 0;
     return tree;
   }
 

--- a/packages/red-black-tree/tests/functions/remove.ts
+++ b/packages/red-black-tree/tests/functions/remove.ts
@@ -1,5 +1,5 @@
 import {assert} from 'chai';
-import {remove, get} from '../../src';
+import {remove, get, set, empty, thaw, size} from '../../src';
 import {RedBlackTreeImpl, Node, isNone} from '../../src/internals';
 import {createTree, getKeys, unsortedValues, verifyRedBlackAdjacencyInvariant, verifyBlackHeightInvariant} from '../test-utils';
 
@@ -18,6 +18,13 @@ suite('[RedBlackTree]', () => {
         tree = <RedBlackTreeImpl<number, string>>remove(unsortedValues[i], tree);
         assert.isUndefined(get(unsortedValues[i], tree), `The key "${unsortedValues[i]}" was not removed`);
       }
+    });
+
+    it('should yield an empty tree when removing the last element of a mutable tree', () => {
+      var tree = thaw(<RedBlackTreeImpl<number, string>>empty());
+      set(1, 'foo', tree);
+      remove(1, tree);
+      assert.strictEqual(size(tree), 0, 'The tree size was not decremented after removing the final element');
     });
 
     test('should reduce the size of the tree by one if the key was found', () => {


### PR DESCRIPTION
The `RedBlackTree.remove` function usually updates the size of the tree, but it has an early exit for the case when a tree only has one node. Previously, the size was not getting updated in this case for mutable trees, so the tree would end up in an invalid state when is should be empty. This commit ensures that the size is correctly updated when removing the final node.