### PR TITLE
RBT(fix): update node values when swapping contents; fixes #44

### DIFF
--- a/packages/red-black-tree/src/internals/ops.ts
+++ b/packages/red-black-tree/src/internals/ops.ts
@@ -136,10 +136,12 @@ export function rotateRightLeft<K, V>(upper: PathNode<K, V>, grandParent: Node<K
 export function swapNodeContents<K, V>(upper: Node<K, V>, lower: Node<K, V> /* ## DEV [[ */, tree: RedBlackTreeStructure<K, V> /* ]] ## */): void {
   log(`[swapNodeContents] upper: ${keyOf(upper)}, lower: ${keyOf(lower)}`); // ## DEV ##
   var key = upper.key;
+  var value = upper.value;
   upper.key = lower.key;
   upper.value = lower.value;
 
   lower.key = key;
+  lower.value = value;
   (<any>upper).__flag = 'swap-key'; // ## DEV ##
   (<any>lower).__flag = 'swap-key'; // ## DEV ##
   log(tree, false, `swap node contents; ${upper.key} <==> ${lower.key}`); // ## DEV ##

--- a/packages/red-black-tree/tests/functions/remove.ts
+++ b/packages/red-black-tree/tests/functions/remove.ts
@@ -85,6 +85,11 @@ suite('[RedBlackTree]', () => {
       assert.isTrue(isNone(tree2._root._right));
     });
 
+    test('should successfully remove the root from a balanced three-node tree', () => {
+      const tree = remove(2, set(2, 'two', set(3, 'three', set(1, 'one', emptyWithNumericKeys<string>()))));
+      assert.strictEqual(get(3, tree), 'three');
+    });
+
     test('should preserve the order of the rest of the tree after a key is removed', () => {
       var tree = createTree();
       for(var i = 0; i < unsortedValues.length; i++) {


### PR DESCRIPTION
When rebalancing a red-black tree, the `swapNodeContents` method is used to exchange the contents of two nodes. Previously, the method was only transferring the key of the upper node without transferring the value, resulting in an incorrect node with the key of one entry and the value of another. This commit ensures that both the key and the value are swapped.