### PR TITLE
ALL(style): support Node 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: node_js
 node_js:
+  - 4
   - 6
   - 7
 script: npm run build-all

--- a/packages/list/src/functions/from.ts
+++ b/packages/list/src/functions/from.ts
@@ -16,6 +16,6 @@ export function fromIterable<T>(values: Iterable<T>): ListStructure<T> {
   return fromArray(Array.from(values));
 }
 
-export function fromArgs<T>(...values: T[]): ListStructure<T> {
-  return fromArray(values);
-}
+export const fromArgs: <T>(...values: T[]) => ListStructure<T> = function() {
+  return fromArray(Array.from(arguments));
+};

--- a/packages/list/src/internals/list.ts
+++ b/packages/list/src/internals/list.ts
@@ -112,7 +112,10 @@ export function cloneList<T>(list: ListStructure<T>, group: number, mutable: boo
   );
 }
 
-export function getView<T>(list: ListStructure<T>, anchor: OFFSET_ANCHOR, asWriteTarget: boolean, preferredOrdinal: number = -1): View<T> {
+export function getView<T>(list: ListStructure<T>, anchor: OFFSET_ANCHOR, asWriteTarget: boolean, preferredOrdinal?: number): View<T> {
+  if (isUndefined(preferredOrdinal)) {
+    preferredOrdinal = -1;
+  }
   var view = anchor === OFFSET_ANCHOR.LEFT ? list._left : list._right;
   log(`[ListState#getView (id:${list.id} a:${anchor === OFFSET_ANCHOR.LEFT ? 'L' : 'R'} g:${list._group})] Attempting to retrieve the ${anchor === OFFSET_ANCHOR.LEFT ? 'LEFT' : 'RIGHT'} view from the state object.`); // ## DEV ##
   if(view.isNone()) {

--- a/packages/list/src/internals/slot.ts
+++ b/packages/list/src/internals/slot.ts
@@ -35,7 +35,7 @@ export class Slot<T> {
     return slot;
   }
 
-  cloneToGroup(group: number, preserveStatus: boolean = false): Slot<T> {
+  cloneToGroup(group: number, preserveStatus?: boolean): Slot<T> {
     if(preserveStatus && this.group < 0) {
       group = -abs(group);
     }
@@ -55,7 +55,7 @@ export class Slot<T> {
     return new Slot<T>(-abs(group), this.size, this.sum, this.recompute, this.subcount, new Array<T>(this.slots.length));
   }
 
-  cloneWithAdjustedRange(group: number, padLeft: number, padRight: number, isLeaf: boolean, preserveStatus: boolean = false): Slot<T> {
+  cloneWithAdjustedRange(group: number, padLeft: number, padRight: number, isLeaf: boolean, preserveStatus?: boolean): Slot<T> {
     if(preserveStatus && this.group < 0) {
       group = -abs(group);
     }

--- a/packages/list/src/internals/traversal.ts
+++ b/packages/list/src/internals/traversal.ts
@@ -181,7 +181,10 @@ export class TreeWorker<T> {
     return !this.other.isNone();
   }
 
-  reset(list: ListStructure<T>, view: View<T>, group: number, otherCommitMode = COMMIT_MODE.NO_CHANGE): TreeWorker<T> {
+  reset(list: ListStructure<T>, view: View<T>, group: number, otherCommitMode?: COMMIT_MODE): TreeWorker<T> {
+    if (isUndefined(otherCommitMode)) {
+      otherCommitMode = COMMIT_MODE.NO_CHANGE;
+    }
     log(`[TreeWorker#reset] RESET WORKER for view: ${view.id} (other view: ${getOtherView(list, view.anchor).isNone() ? 'NONE' : getOtherView(list, view.anchor).id})`); // ## DEV ##
     this.list = list;
     this.current = view;

--- a/packages/list/src/internals/values.ts
+++ b/packages/list/src/internals/values.ts
@@ -97,7 +97,9 @@ export function createIterator<T>(list: ListStructure<T>): IterableIterator<T> {
 
 export function arrayFrom<T>(list: ListStructure<T>): T[] {
   var map = new Map<Slot<T>, Map<number, Slot<T>>>();
-  var [root, depth] = getRoot(list, map);
+  var rootInfo = getRoot(list, map);
+  var root = rootInfo[0];
+  var depth = rootInfo[1];
   if(depth === 0) {
     return copyArray(<T[]>root.slots);
   }
@@ -108,7 +110,9 @@ export function arrayFrom<T>(list: ListStructure<T>): T[] {
 
 export function mapArrayFrom<T, U>(mapper: MapFn<T, U>, list: ListStructure<T>, array: U[]): U[] {
   var map = new Map<Slot<T>, Map<number, Slot<T>>>();
-  var [root, depth] = getRoot(list, map);
+  var rootInfo = getRoot(list, map);
+  var root = rootInfo[0];
+  var depth = rootInfo[1];
   if(depth === 0) {
     blockCopyMapped(mapper, <T[]>root.slots, array, 0, 0, array.length);
   }
@@ -133,11 +137,15 @@ function getRoot<T>(list: ListStructure<T>, map: Map<Slot<T>, Map<number, Slot<T
     if(right.isNone() && left.isRoot()) {
       return [left.slot, 0];
     }
-    [root, depth] = populateViewMap(left, map);
+    const result = populateViewMap(left, map);
+    root = result[0];
+    depth = result[1];
   }
 
   if(!right.isNone()) {
-    [root, depth] = populateViewMap(right, map);
+    var result = populateViewMap(right, map);
+    root = result[0];
+    depth = result[1];
   }
 
   return [root, depth];

--- a/packages/list/src/internals/view.ts
+++ b/packages/list/src/internals/view.ts
@@ -128,7 +128,7 @@ export class View<T> {
     }
   }
 
-  ensureEditable(group: number, ensureSlotEditable = false): View<T> {
+  ensureEditable(group: number, ensureSlotEditable?: boolean): View<T> {
     var view = <View<T>>this;
     if(!view.isEditable(group)) {
       view = view.cloneToGroup(group);
@@ -140,7 +140,7 @@ export class View<T> {
     return view;
   }
 
-  ensureSlotEditable(shallow = false): Slot<T> {
+  ensureSlotEditable(shallow?: boolean): Slot<T> {
     return this.slot.isEditable(this.group) ? this.slot
       : (this.slot = this.slot.cloneToGroup(this.group, true));
   }

--- a/packages/map/src/internals/nodes/ArrayNode/ArrayNode.ts
+++ b/packages/map/src/internals/nodes/ArrayNode/ArrayNode.ts
@@ -28,7 +28,8 @@ export class ArrayNode<K, V> implements ListNode<K, V> {
     hash: number,
     key: K): AnyNode<K, V> {
 
-    const {size: count, children} = this;
+    const count = this.size;
+    const children = this.children;
     const fragment = hashFragment(shift, hash);
     const child = children[fragment];
     const newChild =

--- a/packages/map/src/internals/nodes/IndexedNode/IndexedNode.ts
+++ b/packages/map/src/internals/nodes/IndexedNode/IndexedNode.ts
@@ -34,7 +34,8 @@ export class IndexedNode<K, V> implements Indexed<K, V> {
     hash: number,
     key: K): AnyNode<K, V> {
 
-    const {mask, children} = this;
+    const mask = this.mask;
+    const children = this.children;
     const fragment: number = hashFragment(shift, hash);
     const bit: number = toBitmap(fragment);
     const index: number = bitmapToIndex(mask, bit);

--- a/packages/map/src/internals/primitives/fold.ts
+++ b/packages/map/src/internals/primitives/fold.ts
@@ -5,7 +5,7 @@ export function fold<K, V, R>(
   f: (accum: R, value: V, key: K, index: number) => R,
   seed: R,
   map: HashMapStructure<K, V>,
-  cancelOnFalse = false): R {
+  cancelOnFalse?: boolean): R {
 
   const node = map._root;
 

--- a/packages/map/src/internals/primitives/iterateMap.ts
+++ b/packages/map/src/internals/primitives/iterateMap.ts
@@ -19,7 +19,8 @@ class HashMapIterator<R> implements IterableIterator<R> {
       return {done: true, value: null} as any as IteratorResult<R>;
     }
 
-    const {value, rest} = this._iterate;
+    const value = this._iterate.value;
+    const rest = this._iterate.rest;
 
     this._iterate = continuation(rest);
 

--- a/packages/red-black-tree/src/functions/diff.ts
+++ b/packages/red-black-tree/src/functions/diff.ts
@@ -19,8 +19,13 @@ export function diff<T extends DiffTracer<K, V>, K, V = null>(trace: T, before: 
     return trace;
   }
 
-  let {value: left_item, done: left_done} = left.next(),
-      {value: right_item, done: right_done} = right.next();
+  let leftNext = left.next();
+  let left_item = leftNext.value;
+  let left_done = leftNext.done;
+
+  let rightNext = right.next();
+  let right_item = rightNext.value;
+  let right_done = rightNext.done;
 
   while(!left_done && !right_done) {
     const c = compare(left_item.key, right_item.key);
@@ -36,11 +41,15 @@ export function diff<T extends DiffTracer<K, V>, K, V = null>(trace: T, before: 
     }
 
     if(c <= 0) {
-      ({value: left_item, done: left_done} = traceRemove ? left.next() : left.next(right_item.key));
+      leftNext = traceRemove ? left.next() : left.next(right_item.key);
+      left_item = leftNext.value;
+      left_done = leftNext.done;
     }
 
     if(c >= 0) {
-      ({value: right_item, done: right_done} = traceAdd ? right.next() : right.next(left_item.key));
+      rightNext = traceAdd ? right.next() : right.next(left_item.key);
+      right_item = rightNext.value;
+      right_done = rightNext.done;
     }
   }
 
@@ -48,14 +57,18 @@ export function diff<T extends DiffTracer<K, V>, K, V = null>(trace: T, before: 
     if(traceAdd) {
       while(!right_done) {
         if(trace.added!(right_item) === false) break;
-        ({value: right_item, done: right_done} = right.next());
+        rightNext = right.next();
+        right_item = rightNext.value;
+        right_done = rightNext.done;
       }
     }
   }
   else if(traceRemove) {
     while(!left_done) {
       if(trace.removed!(left_item) === false) break;
-      ({value: left_item, done: left_done} = left.next());
+      leftNext = left.next();
+      left_item = leftNext.value;
+      left_done = leftNext.done;
     }
   }
 

--- a/packages/red-black-tree/src/internals/find.ts
+++ b/packages/red-black-tree/src/internals/find.ts
@@ -268,10 +268,18 @@ function rightOf<K, V>(node: Node<K, V>): Node<K, V> {
 }
 
 export function findNext<K, V>(compare: ComparatorFn<K>, reversed: boolean, inclusive: boolean, key: K, current: PathNode<K, V>): PathNode<K, V>|undefined {
-  const [alreadyVisited, findPath, childOf] = reversed
-    ? [BRANCH.LEFT, findPathToMaxNodeLeftOfKey, leftOf]
-    : [BRANCH.RIGHT, findPathToMinNodeRightOfKey, rightOf];
 
+  let alreadyVisited, findPath, childOf;
+
+  if (reversed) {
+    alreadyVisited = BRANCH.LEFT;
+    findPath = findPathToMaxNodeLeftOfKey;
+    childOf = leftOf;
+  } else {
+    alreadyVisited = BRANCH.RIGHT;
+    findPath = findPathToMinNodeRightOfKey;
+    childOf = rightOf;
+  }
   if(inclusive && compare(key, current.node.key) === 0) {
     inclusive = false;
   }

--- a/packages/red-black-tree/src/internals/iterator.ts
+++ b/packages/red-black-tree/src/internals/iterator.ts
@@ -4,11 +4,11 @@ import {PathNode, clonePath} from './path';
 import {findNext} from './find';
 
 export class RedBlackTreeIterator<K, V> implements IterableIterator<RedBlackTreeEntry<K, V>> {
-  static create<K, V>(current: PathNode<K, V>, compare: ComparatorFn<K>, reversed = false): RedBlackTreeIterator<K, V> {
+  static create<K, V>(current: PathNode<K, V>, compare: ComparatorFn<K>, reversed?: boolean): RedBlackTreeIterator<K, V> {
     if(current.isActive()) {
       current.next = reversed ? BRANCH.RIGHT : BRANCH.LEFT; // indicates the already-traversed branch
     }
-    return new RedBlackTreeIterator(current, compare, reversed);
+    return new RedBlackTreeIterator(current, compare, !!reversed);
   }
 
   private _begun = false;
@@ -124,12 +124,12 @@ export class RedBlackTreeIterator<K, V> implements IterableIterator<RedBlackTree
     return result;
   }
 
-  next(key?: K, inclusive = true): IteratorResult<RedBlackTreeEntry<K, V>> {
-    return isUndefined(key) ? this._next(this._reversed) : this._findNext(this._reversed, inclusive, key);
+  next(key?: K, inclusive?: boolean): IteratorResult<RedBlackTreeEntry<K, V>> {
+    return isUndefined(key) ? this._next(this._reversed) : this._findNext(this._reversed, inclusive !== false, key);
   }
 
-  previous(key?: K, inclusive = true): IteratorResult<RedBlackTreeEntry<K, V>> {
-    return isUndefined(key) ? this._next(!this._reversed) : this._findNext(!this._reversed, inclusive, key);
+  previous(key?: K, inclusive?: boolean): IteratorResult<RedBlackTreeEntry<K, V>> {
+    return isUndefined(key) ? this._next(!this._reversed) : this._findNext(!this._reversed, inclusive !== false, key);
   }
 
   clone(): RedBlackTreeIterator<K, V> {
@@ -144,12 +144,12 @@ export class RedBlackTreeIterator<K, V> implements IterableIterator<RedBlackTree
 export class RedBlackTreeKeyIterator<K, V = null> implements IterableIterator<K> {
   constructor(private _it: RedBlackTreeIterator<K, V>) {}
 
-  next(key?: K, inclusive = true): IteratorResult<K> {
+  next(key?: K, inclusive?: boolean): IteratorResult<K> {
     const result: any = this._it.next(key, inclusive);
     return (result.value = result.value.key, result);
   }
 
-  previous(key?: K, inclusive = true): IteratorResult<RedBlackTreeEntry<K, V>> {
+  previous(key?: K, inclusive?: boolean): IteratorResult<RedBlackTreeEntry<K, V>> {
     const result: any = this._it.previous(key, inclusive);
     return (result.value = result.value.key, result);
   }
@@ -166,12 +166,12 @@ export class RedBlackTreeKeyIterator<K, V = null> implements IterableIterator<K>
 export class RedBlackTreeValueIterator<K, V> implements IterableIterator<V> {
   constructor(private _it: RedBlackTreeIterator<K, V>) {}
 
-  next(key?: K, inclusive = true): IteratorResult<V> {
+  next(key?: K, inclusive?: boolean): IteratorResult<V> {
     const result: any = this._it.next(key, inclusive);
     return (result.value = result.value.value, result);
   }
 
-  previous(key?: K, inclusive = true): IteratorResult<RedBlackTreeEntry<K, V>> {
+  previous(key?: K, inclusive?: boolean): IteratorResult<RedBlackTreeEntry<K, V>> {
     const result: any = this._it.previous(key, inclusive);
     return (result.value = result.value.value, result);
   }

--- a/packages/red-black-tree/src/internals/path.ts
+++ b/packages/red-black-tree/src/internals/path.ts
@@ -30,7 +30,10 @@ export class PathNode<K, V> {
     return p;
   }
 
-  static release<K, V>(p: PathNode<K, V>, node: Node<K, V> = NONE): Node<K, V> {
+  static release<K, V>(p: PathNode<K, V>, node?: Node<K, V>): Node<K, V> {
+    if (isUndefined(node)) {
+      node = NONE;
+    }
     do {
       p.node = NONE;
     }

--- a/packages/red-black-tree/src/internals/unwrap.ts
+++ b/packages/red-black-tree/src/internals/unwrap.ts
@@ -32,7 +32,9 @@ export function unwrap<K, V>(tree: RedBlackTreeStructure<K, V>, target: Associat
       }
     }
     if(branch === BRANCH.NONE && i > 0) {
-      [node, branch] = stack[--i];
+      --i;
+      node = stack[i][0];
+      branch = stack[i][1];
     }
   } while(i > 0 || branch !== BRANCH.NONE);
   return target;

--- a/packages/set/src/functions/intersect.ts
+++ b/packages/set/src/functions/intersect.ts
@@ -28,7 +28,15 @@ export function intersect<T>(other: HashSetStructure<T>|T[]|Iterable<T>, main: H
 }
 
 function intersectHashSet<T>(a: HashMap.Instance<T, null>, b: HashMap.Instance<T, null>, outputMap: HashMap.Instance<T, null>): void {
-  var [inputMap, otherMap] = HashMap.size(b) <= HashMap.size(a) ? [b, a] : [a, b];
+  var inputMap, otherMap;
+
+  if (HashMap.size(b) <= HashMap.size(a)) {
+    inputMap = b;
+    otherMap = a;
+  } else {
+    inputMap = a;
+    otherMap = b;
+  }
   return intersectIterable(inputMap, HashMap.keys(otherMap), outputMap);
 }
 

--- a/packages/set/src/internals/HashSet.ts
+++ b/packages/set/src/internals/HashSet.ts
@@ -109,7 +109,7 @@ export function extractMap<T>(set: HashSetStructure<T>): HashMap.Instance<T, nul
   return set._map;
 }
 
-export function emptySet<T>(mutability: Mutation.PreferredContext = false): HashSetStructure<T> {
+export function emptySet<T>(mutability?: Mutation.PreferredContext): HashSetStructure<T> {
   if(mutability) {
     var mctx = Mutation.selectContext(mutability);
     return new HashSetStructure<T>(mctx, empty<T, null>(Mutation.asSubordinateContext(mctx)));

--- a/packages/sorted-map/src/functions/filter.ts
+++ b/packages/sorted-map/src/functions/filter.ts
@@ -5,10 +5,8 @@ import {size} from './size';
 
 export function filter<K, V, U = any>(fn: KeyedFilterFn<K, V>, map: SortedMapStructure<K, V, U>): SortedMapStructure<K, V, U> {
   var nextSet = modify(map);
-  var {
-    _indexed: keyMap,
-    _sorted: sortedValues,
-  } = nextSet;
+  var keyMap = nextSet._indexed;
+  var sortedValues = nextSet._sorted;
 
   var it = iterate(map);
   var current: IteratorResult<Entry<K, V, U>>;

--- a/packages/sorted-map/src/functions/map.ts
+++ b/packages/sorted-map/src/functions/map.ts
@@ -4,11 +4,9 @@ import {iterate, setItem} from '../internals';
 
 export function map<K, V, R, U = any>(fn: KeyedMapFn<K, V, R>, map: SortedMapStructure<K, V, U>): SortedMapStructure<K, R, U> {
   var nextMap = cloneSortedMap<K, any, U>(map, true, true);
-  var {
-    _indexed: keyMap,
-    _sorted: sortedValues,
-    _select: select
-  } = nextMap;
+  var keyMap = nextMap._indexed;
+  var sortedValues = nextMap._sorted;
+  var select = nextMap._select;
 
   var it = iterate(map);
   var current: IteratorResult<Entry<K, V, U>>;

--- a/packages/sorted-map/src/internals/SortedMap.ts
+++ b/packages/sorted-map/src/internals/SortedMap.ts
@@ -110,7 +110,7 @@ export function isSortedMap<K, V, U>(arg: any): arg is SortedMapStructure<K, V, 
   return isObject(arg) && arg instanceof SortedMapStructure;
 }
 
-export function cloneSortedMap<K, V, U>(map: SortedMapStructure<K, V, U>, clear = false, mutability?: Mutation.PreferredContext): SortedMapStructure<K, V, U> {
+export function cloneSortedMap<K, V, U>(map: SortedMapStructure<K, V, U>, clear?: boolean, mutability?: Mutation.PreferredContext): SortedMapStructure<K, V, U> {
   var mctx = Mutation.selectContext(mutability);
   var sctx = Mutation.asSubordinateContext(mctx);
   var keys: HashMap.Instance<K, Entry<K, V, any>>;

--- a/packages/sorted-set/src/functions/filter.ts
+++ b/packages/sorted-set/src/functions/filter.ts
@@ -5,10 +5,8 @@ import {size} from './size';
 
 export function filter<T>(fn: FilterFn<T>, set: SortedSetStructure<T>): SortedSetStructure<T> {
   var nextSet = modify(set);
-  var {
-    _map: map,
-    _tree: tree,
-  } = nextSet;
+  var map = nextSet._map;
+  var tree = nextSet._tree;
 
   var it = iterateValues(set);
   var current: IteratorResult<any>;

--- a/packages/sorted-set/src/functions/intersect.ts
+++ b/packages/sorted-set/src/functions/intersect.ts
@@ -46,7 +46,9 @@ export function intersect<T>(other: SortedSetStructure<T>|T[]|Iterable<T>, main:
 }
 
 function intersectArray<T>(inputSet: SortedSetStructure<T>, outputSet: SortedSetStructure<T>, array: T[]): void {
-  var {_map: map, _tree: tree, _select: select} = outputSet;
+  var map = outputSet._map;
+  var tree = outputSet._tree;
+  var select = outputSet._select;
   for(var i = 0; i < array.length; i++) {
     if(has(array[i], inputSet)) {
       setItem(array[i], map, tree, select);
@@ -55,7 +57,9 @@ function intersectArray<T>(inputSet: SortedSetStructure<T>, outputSet: SortedSet
 }
 
 function intersectIterable<T>(inputSet: SortedSetStructure<T>, outputSet: SortedSetStructure<T>, it: Iterator<T>): void {
-  var {_map: map, _tree: tree, _select: select} = outputSet;
+  var map = outputSet._map;
+  var tree = outputSet._tree;
+  var select = outputSet._select;
   var current: IteratorResult<T>;
   while(!(current = it.next()).done) {
     if(has(current.value, inputSet)) {

--- a/packages/sorted-set/src/functions/map.ts
+++ b/packages/sorted-set/src/functions/map.ts
@@ -6,11 +6,9 @@ export function map<T, R>(fn: MapFn<T, R>, set: SortedSetStructure<T>): SortedSe
 export function map(fn: MapFn<any, any>, set: SortedSetStructure<any>): SortedSetStructure<any> {
   var immutable = isImmutable(set);
   var nextSet = cloneSortedSet(true, set, true);
-  var {
-    _map: map,
-    _tree: tree,
-    _select: select
-  } = nextSet;
+  var map = nextSet._map;
+  var tree = nextSet._tree;
+  var select = nextSet._select;
 
   var it = iterateValues(set);
   var current: IteratorResult<any>;

--- a/packages/sorted-set/src/functions/subtract.ts
+++ b/packages/sorted-set/src/functions/subtract.ts
@@ -28,14 +28,16 @@ export function subtract<T>(other: SortedSetStructure<T>|T[]|Iterable<T>, main: 
 }
 
 function subtractArray<T>(inputSet: SortedSetStructure<T>, outputSet: SortedSetStructure<T>, omissions: T[]): void {
-  var {_map: map, _tree: tree} = outputSet;
+  var map = outputSet._map;
+  var tree = outputSet._tree;
   for(var i = 0; i < omissions.length; i++) {
     unsetItem(omissions[i], map, tree);
   }
 }
 
 function subtractIterable<T>(inputSet: SortedSetStructure<T>, outputSet: SortedSetStructure<T>, omissions: Iterator<T>): void {
-  var {_map: map, _tree: tree} = outputSet;
+  var map = outputSet._map;
+  var tree = outputSet._tree;
   var current: IteratorResult<T>;
   while(!(current = omissions.next()).done) {
     unsetItem(current.value, map, tree);

--- a/packages/sorted-set/src/functions/union.ts
+++ b/packages/sorted-set/src/functions/union.ts
@@ -25,14 +25,18 @@ export function union<T>(other: SortedSetStructure<T>|T[]|Iterable<T>, main: Sor
 }
 
 function unionArray<T>(inputSet: SortedSetStructure<T>, outputSet: SortedSetStructure<T>, array: T[]): void {
-  var {_map: map, _tree: tree, _select: select} = outputSet;
+  var map = outputSet._map;
+  var tree = outputSet._tree;
+  var select = outputSet._select;
   for(var i = 0; i < array.length; i++) {
     setItem(array[i], map, tree, select);
   }
 }
 
 function unionIterable<T>(inputSet: SortedSetStructure<T>, outputSet: SortedSetStructure<T>, it: Iterator<T>): void {
-  var {_map: map, _tree: tree, _select: select} = outputSet;
+  var map = outputSet._map;
+  var tree = outputSet._tree;
+  var select = outputSet._select;
   var current: IteratorResult<T>;
   while(!(current = it.next()).done) {
     setItem(current.value, map, tree, select);

--- a/packages/sorted-set/src/internals/SortedSet.ts
+++ b/packages/sorted-set/src/internals/SortedSet.ts
@@ -4,6 +4,7 @@ import {
   ComparatorFn,
   SelectorFn,
   isDefined,
+  isUndefined,
   isObject,
   hashIterator,
   unwrap,
@@ -88,7 +89,7 @@ export function isSortedSet<T>(arg: any): arg is SortedSetStructure<T> {
   return isObject(arg) && arg instanceof SortedSetStructure;
 }
 
-export function cloneSortedSet<T>(mutable: boolean, set: SortedSetStructure<T>, clear = false): SortedSetStructure<T> {
+export function cloneSortedSet<T>(mutable: boolean, set: SortedSetStructure<T>, clear?: boolean): SortedSetStructure<T> {
   var mctx = Mutation.selectContext(mutable);
   var sctx = Mutation.asSubordinateContext(mctx);
   var map: HashMapStructure<T, SortedSetItem<T>>;
@@ -156,7 +157,10 @@ function createValueComparatorFn<T>(compare: ComparatorFn<T>): ComparatorFn<Sort
 
 export function emptySet<T>(mutable: boolean|Mutation.Context, compare?: ComparatorFn<T>): SortedSetStructure<T>;
 export function emptySet<T, K>(mutable: boolean|Mutation.Context, compare?: ComparatorFn<K>, select?: SelectorFn<T, K>): SortedSetStructure<T>;
-export function emptySet<T, K>(mutable: boolean|Mutation.Context = false, compare?: ComparatorFn<K>|ComparatorFn<T>, select?: SelectorFn<T, K>): SortedSetStructure<T> {
+export function emptySet<T, K>(mutable?: boolean|Mutation.Context, compare?: ComparatorFn<K>|ComparatorFn<T>, select?: SelectorFn<T, K>): SortedSetStructure<T> {
+  if (isUndefined(mutable)) {
+    mutable = false;
+  }
   var comparator: ComparatorFn<SortedSetItem<T>>
     = isDefined(select) ? createViewComparatorFn<T, K>(<ComparatorFn<K>>compare)
     : isDefined(compare) ? createValueComparatorFn<T>(<ComparatorFn<T>>compare)


### PR DESCRIPTION
- Remove destructuring from packages
- Remove default parameters from packages

This updates the codebase to support Node 4, as described in https://github.com/frptools/collectable/issues/44#issuecomment-314160945. It also adds a Node 4 build to Travis.

Note: As an alternative to changing the syntax of the codebase, another way to do this would be to update the typescript config to compile to ES5. I chose to change the code because it seems like that would result in a much smaller change to the output code, but let me know if it would be better to update the Typescript config instead.