### PR TITLE
MAIN(fix): Error when using setIn() to set a deeply nested value, fixes #55

### DIFF
--- a/src/functions/set.ts
+++ b/src/functions/set.ts
@@ -1,6 +1,9 @@
 import {IndexedCollection, isIndexedCollection} from '@collectable/core';
 import {fromArray} from '@collectable/map';
 
+// Intended to guard isIndexedCollection from testing primitive values
+const isPrimitive = (value) => Object(value) !== value;
+
 export function setIn<K, V>(path: any[], value: any, collection: IndexedCollection<K, V>): IndexedCollection<K, V> {
   collection = setDeep(collection, path, 0, value);
   return collection;
@@ -8,7 +11,7 @@ export function setIn<K, V>(path: any[], value: any, collection: IndexedCollecti
 
 function setDeep(collection: IndexedCollection<any, any>, path: any[], keyidx: number, value: any): IndexedCollection<any, any> {
   var key = path[keyidx];
-  if(isIndexedCollection(collection) && IndexedCollection.verifyKey(key, collection)) {
+  if (!isPrimitive(collection) && isIndexedCollection(collection) && IndexedCollection.verifyKey(key, collection)) {
     return keyidx === path.length - 1
       ? IndexedCollection.set(key, value, collection)
       : IndexedCollection.updateEntry((c: any) => setDeep(c, path, keyidx + 1, value), key, collection);

--- a/tests/functions/set.ts
+++ b/tests/functions/set.ts
@@ -1,0 +1,38 @@
+import {assert} from 'chai';
+import {from, setIn, unwrap} from '../../src';
+
+suite('[Main]', () => {
+  suite('setIn()', () => {
+    test('should set any keys defined in the path that are undefined on the target collection', () => {
+      const emptyTarget = from({});
+      const desiredValue = true;
+      const nestedPath = ['a', 'b', 'c', 'd', 'e'];
+
+      const actual = unwrap(setIn(nestedPath, desiredValue, emptyTarget));
+      const expected = {a: {b: {c: {d: {e: true}}}}};
+      assert.deepEqual(actual, expected);
+    });
+
+    test('should overwrite existing values along the given path', () => {
+      const target = from({a: true});
+      const desiredValue = true;
+      const nestedPath = ['a', 'b', 'c', 'd', 'e'];
+
+      const actual = unwrap(setIn(nestedPath, desiredValue, target));
+      const expected = {a: {b: {c: {d: {e: true}}}}};
+      assert.deepEqual(actual, expected);
+    });
+
+    test('does not mutate the target collection', () => {
+      const emptyTarget = from({});
+      const desiredValue = true;
+      const nestedPath = ['a', 'b', 'c', 'd', 'e'];
+
+      setIn(nestedPath, desiredValue, emptyTarget);
+
+      const actual = unwrap(emptyTarget);
+      const expected = {};
+      assert.deepEqual(actual, expected);
+    });
+  });
+});


### PR DESCRIPTION
- Includes guard that prevents isIndexedCollection() from running against primitive values
- Includes test coverage to prove deep nested writing and overwriting function