### PR TITLE
Fix sorted map always using insertion order when created as mutable

### DIFF
--- a/packages/map/src/internals/primitives/unwrap.ts
+++ b/packages/map/src/internals/primitives/unwrap.ts
@@ -1,15 +1,15 @@
-import { Associative, isObject, unwrap, unwrapKey } from '@collectable/core';
+import { Associative, unwrap, unwrapKey } from '@collectable/core';
 import { HashMapStructure } from '../HashMap';
 import { identity, iterator } from './index';
 import { Leaf } from '../nodes';
 
 export function unwrapInto<K, V> (target: Associative<V>, map: HashMapStructure<K, V>): Associative<V> {
- var it = iterator(map._root, identity);
+  var it = iterator(map._root, identity);
   var current: IteratorResult<Leaf<K, V>>;
   while(!(current = it.next()).done) {
     var entry = current.value;
     var value = entry.value;
-    target[unwrapKey(entry.key)] = isObject(value) ? unwrap<V>(value) : value;
+    target[unwrapKey(entry.key)] = unwrap<V>(value);
   }
   return target;
 }

--- a/packages/red-black-tree/src/functions/fromKeys.ts
+++ b/packages/red-black-tree/src/functions/fromKeys.ts
@@ -12,7 +12,8 @@ export function fromKeys<K> (compare: ComparatorFn<K>, keys: K[]|RedBlackTreeStr
     }
   }
   else {
-    const it = isRedBlackTree<K>(keys) ? iterateKeysFromFirst(keys) : keys[Symbol.iterator]();
+    const iterable = isRedBlackTree<K>(keys) ? iterateKeysFromFirst(keys) : keys;
+    const it = iterable[Symbol.iterator]();
     var current: IteratorResult<K>;
     while(!(current = it.next()).done) {
       set(current.value, null, tree);

--- a/packages/sorted-map/src/functions/empty.ts
+++ b/packages/sorted-map/src/functions/empty.ts
@@ -20,6 +20,7 @@ export function empty<K, V, U> (
     mutable = false;
   }
   else {
+    compare = <ComparatorFn<SortedMapEntry<K, V, U>>>arg1;
     mutable = isMutationContext(arg0) || isBoolean(arg0) ? arg0 : false;
   }
   return emptySortedMap<K, V, U>(compare, select, mutable);

--- a/packages/sorted-map/tests/functions/empty.ts
+++ b/packages/sorted-map/tests/functions/empty.ts
@@ -1,5 +1,11 @@
 import test from 'ava';
-import { empty, size } from '../../src';
+import { ComparatorFn, numericCompare } from '@frptools/corelib';
+import { empty, set, size, SortedMapEntry, firstValue, lastValue } from '../../src';
+
+interface Item {
+  id: number;
+  time: number;
+}
 
 test('returns a map with size 0', t => {
   t.is(size(empty()), 0);
@@ -8,4 +14,29 @@ test('returns a map with size 0', t => {
 test('always returns the same set instance if called with no arguments', t => {
   const a = empty(), b = empty();
   t.is(a, b);
+});
+
+test('sorts added items', t => {
+  const compare: ComparatorFn<SortedMapEntry<number, Item, number>> = (x, y) => numericCompare(x.view, y.view);
+  const map = empty<number, Item, number>(true, compare, x => x.time);
+
+  const now = new Date();
+  for (let i = 0; i < 15; i++)   {
+    const item = {
+      id: (i + 1),
+      time: new Date(now.getFullYear(), now.getMonth(), now.getDate() - (i + 1)).valueOf()
+    };
+
+    set(item.id, item, map);
+  }
+
+  t.deepEqual(firstValue(map), {
+    id: 15,
+    time: new Date(now.getFullYear(), now.getMonth(), now.getDate() - 15).valueOf()
+  });
+
+  t.deepEqual(lastValue(map), {
+    id: 1,
+    time: new Date(now.getFullYear(), now.getMonth(), now.getDate() - 1).valueOf()
+  });
 });


### PR DESCRIPTION
Pass compare function to sorted map when calling empty using mutable overload.